### PR TITLE
feat: Process user-provided config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 cc_icon*
+config.yml
 
 start_banner*
 !start_banner.typ

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ original_end_banner.svg:
 %.png: %.pdf
 	${pdftocairo} -scale-to-x 1920 -scale-to-y 1080 -singlefile -png "$<" "$*"
 
+# Ensures the files are "rebuilt" when any of their prerequisites (defined later on) are updated.
+# Otherwise changes to e.g. the `config.yml` or `common.typ` will not cause a rebuild. Since the
+# files are part of the git repo it's safe to assume they always exist.
+start_banner.typ end_banner.typ:
+	@touch -c "$@"
+
 # Use rasterized versions of the logos because typst ruins the SVGs for display.
 start_banner.typ end_banner.typ: common.typ cc_icon_logo.jpeg cc_icon_sa.jpeg cc_icon_by.jpeg
 

--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,19 @@ MAGICKFLAGS =
 magick = ${MAGICK} ${MAGICKFLAGS}
 
 default: start_banner.png end_banner.png
-	@echo "Outputs are available in: $^"
+	@echo -e "\e[1;35mOutputs are available in: $^\e[0m"
 
+# Just for comparison
 original_start_banner.svg:
 	${curl} -o "$@" "https://www.noname-ev.de/wiki/uploads/1/13/Banner_2.svg"
 
 original_end_banner.svg:
 	${curl} -o "$@" "https://www.noname-ev.de/wiki/uploads/3/3c/Banner_1.svg"
 
+
+#
+# Start and End Banner
+#
 %.svg: %.typ
 	${typst} compile -f "svg" "$<" "$@"
 
@@ -104,6 +109,9 @@ config.yml:
 	YAML
 
 
+#
+# Maintenance and stuff
+#
 .PHONY: clean
 clean:
 	rm -rf cc_icon_{logo,sa,by}.jpeg

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,27 @@ cc_icon_%.jpeg: cc_icon_%.svg
 	${magick} -background "#000000" -density 1200 -quality 92 "nnev_$<" "$@"
 	rm -f "nnev_$<"
 
+
+#
+# Config handling
+#
+start_banner.typ: config.yml
+
+# No reason to be so strict with naming
+%.yml: %.yaml
+	cp "$<" "$@"
+
+config.yml:
+	@cat <<-YAML > "$@"
+		title: Ein recht langer Titel
+		subtitle: |
+		    Untertitel
+		    mit Zeilenumbruch!
+		author: Chaotischer Chaot
+		date: 2025-06-12
+	YAML
+
+
 .PHONY: clean
 clean:
 	rm -rf cc_icon_logo.jpeg cc_icon_sa.jpeg cc_icon_by.jpeg

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,8 @@ config.yml:
 
 .PHONY: clean
 clean:
-	rm -rf cc_icon_logo.jpeg cc_icon_sa.jpeg cc_icon_by.jpeg
+	rm -rf cc_icon_{logo,sa,by}.jpeg
+	rm -rf {start,end}_banner.{png,pdf,svg,jpeg}
 
 .PHONY: mrproper
 mrproper: clean

--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 <!--toc:start-->
 - [c14h Start-/Endfolien][0]
     - [Benutzen][a]
+    - [Vorbereiten][b]
     - [Lizenz][d]
 
 [0]: #c14h-start-endfolien
 [a]: #benutzen
+[b]: #vorbereiten
 [d]: #lizenz
 <!--toc:end-->
 
@@ -17,12 +19,34 @@ Die Start- und Endfolien bzw. Banner für die Videouploads der [chaotischen Vier
 
 ## Benutzen
 
+Vor dem ersten Benutzen, sollte man die Ausführung des Projektes [einmal vorbereiten][b].
+
+Die Metadaten für das Startbanner werden aus einer Konfigurationsdatei `config.yml` ausgelesen. Eine
+Standardkonfiguration wird automatisch von `make` erzeugt, sofern keine vorhanden ist. Man kann sie
+aber mit folgendem Befehl auch händisch erzeugen:
+
+```bash
+bin/make config.yml
+```
+
+Anschließend muss man die Einstellungen mit einem Editor anpassen. Wenn die Konfiguration die
+gewünschten Werte enthält, werden die Banner wie folgt erzeugt:
+
+```bash
+bin/make
+```
+
+Die erzeugten Dateien zeigt das `Makefile` anschließend in der Ausgabe an.
+
+
+## Vorbereiten
+
 Dieses repo nutzt GNU `make` als Buildsystem und einen OCI-Container für das Verwalten der
 Abhängigkeiten. Um das repo zu benutzen, müssen wenigstens folgende Programme installiert sein:
 
-- [GNU bash][a0]
-- [GNU coreutils][a1] (oder eine andere Implementierung von `realpath`, `basename` und `dirname`)
-- [podman][a2]
+- [GNU bash][b0]
+- [GNU coreutils][b1] (oder eine andere Implementierung von `realpath`, `basename` und `dirname`)
+- [podman][b2]
 
 Anschließend baut man einmal den Container:
 
@@ -38,13 +62,13 @@ bin/make
 ```
 
 > Hinweis: Sofern die Installation/Anwendung von `podman` keine Option ist, kann man die benötigten
-> Abhängigkeiten auch lokal installieren. Das [Containerfile.develop][a3] zeigt, was benötigt wird.
+> Abhängigkeiten auch lokal installieren. Das [Containerfile.develop][b3] zeigt, was benötigt wird.
 > **Für dieses Setup gibt es allerdings keine Unterstützung von uns!**
 
-[a0]: https://www.gnu.org/software/bash/
-[a1]: https://www.gnu.org/software/coreutils/
-[a2]: https://podman.io/
-[a3]: ./Containerfile.develop
+[b0]: https://www.gnu.org/software/bash/
+[b1]: https://www.gnu.org/software/coreutils/
+[b2]: https://podman.io/
+[b3]: ./Containerfile.develop
 
 
 ## Lizenz

--- a/start_banner.typ
+++ b/start_banner.typ
@@ -1,12 +1,54 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #import("common.typ"): *
 
-#let metadata = (
-    title: "Ein recht langer Titel",
-    subtitle: "Untertitel\nmit Zeilenumbruch!",
-    author: "Chaotischer Chaot",
-    date: datetime(year: 2025, month: 06, day: 12),
-)
+#let metadata = {
+    let obj = (:)
+    let config_dict = () => {
+        let config_path = "config.yml"
+        let raw_config = yaml(config_path)
+
+        if type(raw_config) == dictionary {
+            raw_config
+        } else {
+            panic("The config file '" + config_path + "' must specify a dictionary/key-value mapping")
+        }
+    }
+
+    let update_key(obj, key, required: true, transform: x => x) = {
+        if key in sys.inputs {
+            obj.insert(key, transform(sys.inputs.at(key)))
+        } else if key in config_dict() {
+            obj.insert(key, transform(config_dict().at(key)))
+        } else {
+            if required {
+                panic("required variable '" + str(key) + "' is undefined")
+            }
+        }
+        obj
+    }
+
+    obj = update_key(obj, "title")
+    obj = update_key(obj, "subtitle", required: false)
+    obj = update_key(obj, "author")
+    obj = update_key(obj, "date", transform: dt => {
+        let year_pattern = "(?P<year>\d{4})"
+        let month_pattern = "(?P<month>(?:0?[1-9])|(?:1[0-2]))"
+        let day_pattern = "(?P<day>(?:0?[0-9])|(?:[12][0-9])|(?:3[01]))"
+        let match = dt.match(regex("^" + year_pattern + "-" + month_pattern + "-" + day_pattern + "$"))
+
+        if match == none {
+            panic("Date string must satisfy format 'yyyy-mm-dd'")
+        } else {
+            datetime(
+                year: int(match.captures.at(0)),
+                month: int(match.captures.at(1)),
+                day: int(match.captures.at(2)),
+            )
+        }
+    })
+
+    obj
+}
 
 #banner[
     #block(

--- a/start_banner.typ
+++ b/start_banner.typ
@@ -63,7 +63,9 @@
         )[
             #text(theme.fontsizes.title, metadata.title, weight: "bold")
             #v(1.6em, weak: true)
-            #text(theme.fontsizes.subtitle, metadata.subtitle, weight: "bold")
+            #if "subtitle" in metadata {
+                text(theme.fontsizes.subtitle, metadata.subtitle, weight: "bold")
+            }
         ],
     )
     #block(


### PR DESCRIPTION
Introduce a `config.yml` where the actual content for the start banner is read from. Update the `Makefile` to recognize changes to this config and rebuild the start and end banners if required. Document the existence of `config.yml` in the README so users can actually find it.

Previously, creating the banners required users to modify the `.typ` source files directly, which wasn't exactly a great UX. With the config file approach it's now possible to integrate banner generation into overarching workflows more easily, since the config can be provided from external sources.