### PR TITLE
Handle SVG replacements entirely inside typst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ original_end_banner.svg:
 # Start and End Banner
 #
 %.svg: %.typ
-    ${typst} compile -f "svg" "$<" "$@"
+	${typst} compile -f "svg" "$<" "$@"
 
 %.pdf: %.typ
 	${typst} compile -f "pdf" "$<" "$@"

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ start_banner.typ end_banner.typ:
 	@touch -c "$@"
 
 # Use rasterized versions of the logos because typst ruins the SVGs for display.
-start_banner.typ end_banner.typ: common.typ
-start_banner.typ: nnev_cc_icon_logo.svg nnev_cc_icon_sa.svg nnev_cc_icon_by.svg
+start_banner.typ end_banner.typ: \
+	common.typ nnev_cc_icon_logo.svg nnev_cc_icon_sa.svg nnev_cc_icon_by.svg
 end_banner.typ: nnev_logo_red.svg
 
 cc_icon_logo.svg:

--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,8 @@ start_banner.typ end_banner.typ:
 	@touch -c "$@"
 
 # Use rasterized versions of the logos because typst ruins the SVGs for display.
-start_banner.typ end_banner.typ: \
-	common.typ nnev_cc_icon_logo.svg nnev_cc_icon_sa.svg nnev_cc_icon_by.svg
-end_banner.typ: nnev_logo_red.svg
+start_banner.typ end_banner.typ: common.typ cc_icon_logo.svg cc_icon_sa.svg cc_icon_by.svg
+end_banner.typ: nnev_logo.svg
 
 cc_icon_logo.svg:
 	${curl} -o "$@" "https://mirrors.creativecommons.org/presskit/icons/cc.svg"
@@ -70,11 +69,6 @@ cc_icon_sa.svg:
 cc_icon_by.svg:
 	${curl} -o "$@" "https://mirrors.creativecommons.org/presskit/icons/by.svg"
 
-nnev_logo_red.svg: nnev_logo.svg
-	sed -E -e 's/fill:#000000/fill:#E12617/g' "$<" > "$@"
-
-nnev_cc_icon_%.svg: cc_icon_%.svg
-	sed -E -e 's/path /path fill="#E12617" /g' -e 's/FFFFFF/000000/g' "$<" > "$@"
 
 #
 # Config handling
@@ -101,7 +95,6 @@ config.yml:
 #
 .PHONY: clean
 clean:
-	rm -f nnev_cc_icon_{logo,sa,by}.svg
 	rm -f {start,end}_banner.{png,svg,pdf}
 
 .PHONY: mrproper

--- a/common.typ
+++ b/common.typ
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+/// General banner theme
 #let theme = (
     background: rgb("#000000"),
     foreground: rgb("#E12617"),
@@ -9,6 +11,26 @@
         date: 18pt,
     ),
 )
+
+/// Prepare a Creative Commons Icon for display in the banner.
+///
+/// Overwrites the background and foreground colors to match the configured theme.
+///
+/// -> bytes
+#let cc_icon(
+    /// Path to the (unmodified) CC icon to convert. The icon must be a SVG file.
+    ///
+    /// -> str
+    path
+) = {
+    let raw_svg = read(path, encoding: "utf8")
+    // Adapt foreground color to whatever the theme says
+    let fix_fg = raw_svg.replace("path ", "path fill=\"" + theme.foreground.to-hex() + "\" ")
+    // Adapt background color to whatever the theme says
+    let themed_icon = fix_fg.replace("FFFFFF", theme.background.to-hex())
+
+    bytes(themed_icon)
+}
 
 /// Prepare the NoName e.V. logo for display in the banner.
 ///
@@ -60,9 +82,9 @@
                     columns: (1cm, 1cm, 1cm),
                     gutter: 5pt,
                     align: (center, center, center),
-                    image("nnev_cc_icon_logo.svg"),
-                    image("nnev_cc_icon_by.svg"),
-                    image("nnev_cc_icon_sa.svg"),
+                    image(cc_icon("cc_icon_logo.svg")),
+                    image(cc_icon("cc_icon_by.svg")),
+                    image(cc_icon("cc_icon_sa.svg")),
                 )
                 #v(-0.7em)
                 #link("https://creativecommons.org/licenses/by-sa/4.0/")

--- a/common.typ
+++ b/common.typ
@@ -10,6 +10,24 @@
     ),
 )
 
+/// Prepare the NoName e.V. logo for display in the banner.
+///
+/// Overwrites the foreground (stroke) color to match the configured theme.
+///
+/// -> bytes
+#let nnev_logo(
+    /// Path to the base (unmodified) NoName e.V. logo. The logo must be a SVG file.
+    ///
+    /// -> str
+    path
+) = {
+    let raw_svg = read(path, encoding: "utf8")
+    // Adapt foreground color to whatever the theme says
+    let themed_icon = raw_svg.replace("fill:#000000", "fill:" + theme.foreground.to-hex())
+
+    bytes(themed_icon)
+}
+
 #let banner(content, theme: theme) = {
     set text(
         fill: theme.foreground,

--- a/end_banner.typ
+++ b/end_banner.typ
@@ -8,7 +8,7 @@
         spacing: 0pt,
         align(
             horizon,
-            image("nnev_logo_red.svg", width: 80%),
+            image(nnev_logo("nnev_logo.svg"), width: 80%),
         ),
     )
 ]


### PR DESCRIPTION
Previously the `Makefile` took care of modifying SVG files to match the color theme configured in typst. This was required because the `Makefile` also converted the SVGs to JPEGs in order to prevent issues with rasterized outputs.

Now that #3 has landed, we're not using the crutch with JPEG images any longer. Hence we can modify the raw SVG code inside typst, which a) saves us the trouble of creating converted files on disk and b) means we can perform all the theming inside `typst` and not in `typst` and the `Makefile`. The latter aspect was poorly implemented before, since the themes foreground color had simply been copied to the `Makefile` for use there...